### PR TITLE
camera_id scan limit 2 -> 8 (Support many cameras plugged in)

### DIFF
--- a/src/mytest.cpp
+++ b/src/mytest.cpp
@@ -81,7 +81,7 @@ int do_stuff() {
   bool ok;
   int camera_id = -1;
   librealuvc::VideoCapture cap;
-  for (int id = 0; id < 2; ++id) {
+  for (int id = 0; id < 8; ++id) {
     ok = cap.open(id);
     if (ok) {
       D("camera_id %d vendor 0x%04x product 0x%04x", 


### PR DESCRIPTION
I was trying to figure out why my Rigel wasn't being detected and found out it was just because the test script wasn't reaching its id in the device enumeration.