### PR TITLE
Use xu bUnitID as reported by lsusb

### DIFF
--- a/src/driver_rigel.cpp
+++ b/src/driver_rigel.cpp
@@ -43,7 +43,7 @@ class PropertyDriverRigel : public IPropertyDriver {
     leds_(0) {
     D("PropertyDriverRigel::ctor() ...");
     leap_xu_.subdevice = 0;
-    leap_xu_.unit = 1;
+    leap_xu_.unit = 224;
     leap_xu_.node = 4;
     leap_xu_.id = guid LEAP_XU_GUID;
     try {


### PR DESCRIPTION
There seems to be two EXTENSION_UNIT on the Rigel. One with bUnitID=4
and one with bUnitID=224.

The bUnitID matching the descriptor with the same guid as LEAP_XU_GUID
is 224.

Looking at where this is used, it looks like only Windows will use the
LEAP_XU_GUID stored in `leap_xu_.id`, both macOS and Linux use
`leap_xu_.unit`.

I've not found `leap_xu_.node` used anywhere.