### PR TITLE
Revert export shared target name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ if(BUILD_SHARED_LIBS)
     VERSION ${REALUVC_VERSION_STRING}
     SOVERSION ${REALUVC_VERSION_MAJOR}
 )
+  set_property(TARGET ${LRS_TARGET}_shared
+    PROPERTY
+      EXPORT_NAME ${LRS_TARGET}
+)
 endif()
 
 # add_OpenCV()


### PR DESCRIPTION
Unfortunately CMake does not suppot ALIAS for exported TARGETS.