### PR TITLE
Prevent never ending thread on device disconnect

### DIFF
--- a/include/librealuvc/realuvc_driver.h
+++ b/include/librealuvc/realuvc_driver.h
@@ -65,7 +65,7 @@ class DevFrameQueue {
     const std::function<void()>& release_func
   );
   
-  void pop_front(ru_time_t& ts, cv::Mat& mat);  
+  bool pop_front(ru_time_t& ts, cv::Mat& mat);  
 };
 
 } // end librealuvc

--- a/src/videocapture.cpp
+++ b/src/videocapture.cpp
@@ -374,7 +374,11 @@ bool VideoCapture::read(cv::OutputArray image) {
     if (!istream->is_streaming_) return false;
   } // don't hold the mutex while possibly waiting for frame
   cv::Mat tmp;
-  istream->queue_.pop_front(istream->frame_time_, tmp); // wait for a frame if necessary
+  
+  // wait for a frame, or return false if timeout reached
+  if (!istream->queue_.pop_front(istream->frame_time_, tmp))
+    return false;
+
   if (image.needed()) {
     // OutputArray::assign() will not copy unless it needs to
     image.assign(tmp);


### PR DESCRIPTION
Added 250ms timout to pop_front, returning false on timeout.
This is passed to VideoCapture::read() which passes the false upwards.