### PR TITLE
Enable pulse width modulation control for the rigel device

### DIFF
--- a/include/librealuvc/ru_videocapture.h
+++ b/include/librealuvc/ru_videocapture.h
@@ -116,6 +116,7 @@ enum CapPropLeap {
   CAP_PROP_LEAP_BASE = 100,
   CAP_PROP_LEAP_HDR  = 101,
   CAP_PROP_LEAP_LEDS = 102,
+  CAP_PROP_LEAP_PULSEWIDTHMODULATION = 103
 };
 
 class VideoCapture : public cv::VideoCapture {

--- a/src/driver_rigel.cpp
+++ b/src/driver_rigel.cpp
@@ -98,6 +98,13 @@ class PropertyDriverRigel : public IPropertyDriver {
       case CAP_PROP_LEAP_LEDS:
         *val = leds_;
         break;
+      case CAP_PROP_LEAP_PULSEWIDTHMODULATION: {
+        uint32_t tmp;
+        ok = dev_->get_xu(leap_xu_, LEAP_XU_ESC_PULSE_WIDTH, (uint8_t*)&tmp, sizeof(tmp));
+        if (ok) {
+          *val = static_cast<double>(tmp);
+        }
+      } break;
       default:
         return kHandlerNotDone;
     }
@@ -171,6 +178,10 @@ class PropertyDriverRigel : public IPropertyDriver {
         if (ok) leds_ = val;
         break;
       }
+      case CAP_PROP_LEAP_PULSEWIDTHMODULATION: {
+        const auto tmp = static_cast<uint32_t>(val);
+        ok = dev_->set_xu(leap_xu_, LEAP_XU_ESC_PULSE_WIDTH, (uint8_t*)&tmp, sizeof(tmp));
+      } break;
       default:
         return kHandlerNotDone;
     }

--- a/src/videocapture.cpp
+++ b/src/videocapture.cpp
@@ -578,11 +578,21 @@ shared_ptr<OpaqueCalibration> VideoCapture::get_opaque_calibration() {
 }
 
 bool VideoCapture::get_xu(int ctrl, void* data, int len) {
-  return false;
+  if (!driver_) {
+    return false;
+  }
+  
+  auto res = driver_->get_prop(ctrl, (double*) data);
+  return res == librealuvc::HandlerResult::kHandlerTrue;
 }
 
 bool VideoCapture::set_xu(int ctrl, const void* data, int len) {
-  return false;
+  if (!driver_) {
+    return false;
+  }
+
+  auto res = driver_->set_prop(ctrl, *(double*) data);
+  return res == librealuvc::HandlerResult::kHandlerTrue;
 }
 
 } // end librealuvc


### PR DESCRIPTION
Wires up the interface through get/set_xu, and then forwards to underlying leap extension/libuvc to do the work.