### PR TITLE
[FEAT] Support conan-based installation of librealuvc dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,9 @@ jobs:
         run: |
           conan build . --build-folder build
 
+      - name: Copy OpenCV .dll's to Build Artifacts
+        run: xcopy ~\.conan\2d8994\1\bin .\build\bin
+
       - name: Upload Windows Library
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,12 @@ jobs:
 
       - name: Copy OpenCV .dll's to Build Artifacts
         run: |
+          ls C:\
+          ls C:\.conan
+          ls C:\.conan\*\*\*\*
           xcopy C:\.conan\2d8994\0\bin .\build\bin
 
       - name: Upload Windows Library
-        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: librealuvc-windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          conan install . --install-folder build -r conan-center -s compiler='Visual Studio' -s compiler.version="16"
+          conan install . --build-folder build -r conan-center -s compiler='Visual Studio' -s compiler.version="16"
 
       - name: Build Windows Library
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,29 @@ jobs:
         with:
           lfs: true
 
+      - name: Cache Pip Packages
+        uses: actions/cache@v2
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install Conan
         run: |
           pip install conan
 
+      - name: Cache Conan Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~\.conan
+          key: ${{ runner.os }}-conan-
+          restore-keys: |
+            ${{ runner.os }}-conan-
+
       - name: Install Dependencies
         run: |
-          conan install . --install-folder build -r conan-center -s compiler='Visual Studio' -s compiler.version="15"
+          conan install . --install-folder build -r conan-center -s compiler='Visual Studio' -s compiler.version="16"
 
       - name: Build Windows Library
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Install Conan
         run: |
           pip install conan
-          conan remote add conan-center https://conan.bintray.com
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,11 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          conan install . --build-folder build -r conan-center -s compiler='Visual Studio' -s compiler.version="16"
+          conan install . --install-folder build -r conan-center -s compiler='Visual Studio' -s compiler.version="16"
 
       - name: Build Windows Library
         run: |
-          conan build . --install-folder build
+          conan build . --build-folder build
 
       - name: Upload Windows Library
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: librealuvc - Continuous Integration
+
+on:
+  push
+
+jobs:
+  build-win:
+    name: Build Windows Library
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      - name: Install Conan
+        run: |
+          pip install conan
+          conan remote add conan-center https://conan.bintray.com
+
+      - name: Install Dependencies
+        run: |
+          conan install . --install-folder build -r conan-center -s compiler='Visual Studio' -s compiler.version="15"
+
+      - name: Build Windows Library
+        run: |
+          conan build . --install-folder build
+
+      - name: Upload Windows Library
+        uses: actions/upload-artifact@v2
+        with:
+          name: librealuvc-windows
+          path: build/bin/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,10 @@ jobs:
 
       - name: Copy OpenCV .dll's to Build Artifacts
         run: |
-          xcopy C:\.conan\2d8994\1\bin .\build\bin
+          xcopy C:\.conan\2d8994\0\bin .\build\bin
 
       - name: Upload Windows Library
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: librealuvc-windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,8 @@ jobs:
 
       - name: Copy OpenCV .dll's to Build Artifacts
         run: |
-          ls C:\
-          ls C:\.conan
           ls C:\.conan\*\*\*\*
-          xcopy C:\.conan\2d8994\0\bin .\build\bin
+          xcopy C:\.conan\194228\1\bin .\build\bin
 
       - name: Upload Windows Library
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-conan-
 
+      - name: Cache Conan Binaries
+        uses: actions/cache@v2
+        with:
+          path: C:\.conan
+          key: ${{ runner.os }}-conan-binaries-
+          restore-keys: |
+            ${{ runner.os }}-conan-binaries-
+
       - name: Install Dependencies
         run: |
           conan install . --install-folder build -r conan-center -s compiler='Visual Studio' -s compiler.version="16"
@@ -42,7 +50,8 @@ jobs:
           conan build . --build-folder build
 
       - name: Copy OpenCV .dll's to Build Artifacts
-        run: xcopy ~\.conan\2d8994\1\bin .\build\bin
+        run: |
+          xcopy C:\.conan\2d8994\1\bin .\build\bin
 
       - name: Upload Windows Library
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ ubuntu-xenial-hwe/
 build/
 connectivity_check
 
+# conan
+_deps
+
 # XCode
 .DS_Store
 *.pbxuser

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(librealuvc LANGUAGES CXX C)
 
+set(CONAN_DISABLE_CHECK_COMPILER True)
+
 # -------
 # Modules
 # -------
@@ -42,7 +44,7 @@ add_library(${LRS_TARGET} "")
 # ---------------------
 
 # Basic Conan setup. conanbuildinfo.cmake is produced by the `conan install` command, which references conanfile.py.
-include(${CMAKE_BINARY_DIR}/build/conanbuildinfo.cmake)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 # To support OpenCV and any other conan-based libraries, conan_basic_setup() is almost all we need. However, the test targets require specific add_library invocations, which is provided by this additional macro provided by conanbuildinfo.cmake.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(librealuvc LANGUAGES CXX C)
 
-set(CONAN_DISABLE_CHECK_COMPILER True)
-
 # -------
 # Modules
 # -------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,34 +37,29 @@ global_set_flags()
 message(STATUS "add_library: ${LRS_TARGET} SHARED: ${BUILD_SHARED_LIBS}")
 add_library(${LRS_TARGET} "")
 
-# Conan
-# -----
-# Basic Conan setup.
+# ---------------------
+# Libraries - via Conan
+# ---------------------
+
+# Basic Conan setup. conanbuildinfo.cmake is produced by the `conan install` command, which references conanfile.py.
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-# OpenCV
-# ------
+# To support OpenCV and any other conan-based libraries, conan_basic_setup() is almost all we need. However, the test targets require specific add_library invocations, which is provided by this additional macro provided by conanbuildinfo.cmake.
+# 
+# This invokes add_library(CONAN_PKG::opencv ...), which replaces old references to the OpenCV dependency from before the conan setup. In src/CMakeLists.txt executables that use OpenCV for viewing camera output are now able to depend on CONAN_PKG::opencv and any other specific packages we're getting through conan.
+conan_define_targets()
 
-# CURRENT STATUS: Seeing if conan_basic_setup pulls in OpenCV just fine...
-
+# -------------------
+# OpenCV -- Reference
+# -------------------
 # Old non-Conan OpenCV inclusion.
-# ---
+
 # # add_OpenCV() (from global_config.cmake)
 # find_package(OpenCV REQUIRED)
 # set(DEPENDENCIES librealuvc ${OpenCV_LIBS})
 # include_directories(${OpenCV_INCLUDE_DIRS})
 # add_library(OpenCV SHARED IMPORTED)
-# ---
-# Conan OpenCV.
-conan_define_targets()
-# find_package(OpenCV REQUIRED) # Nope
-# set(OpenCV_LIBS ${CONAN_LIBS_OPENCV})
-# set(OpenCV_INCLUDE_DIRS ${CONAN_INCLUDE_DIRS_OPENCV})
-# set(DEPENDENCIES librealuvc ${OpenCV_LIBS})
-# include_directories(${OpenCV_INCLUDE_DIRS})
-# target_link_libraries(${LRS_TARGET} PUBLIC ${OpenCV_LIBS})
-# target_include_directories(${LRS_TARGET} PUBLIC ${OpenCV_INCLUDE_DIR})
 
 # ------------------
 # More Configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library(${LRS_TARGET} "")
 # ---------------------
 
 # Basic Conan setup. conanbuildinfo.cmake is produced by the `conan install` command, which references conanfile.py.
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+include(${CMAKE_BINARY_DIR}/build/conanbuildinfo.cmake)
 conan_basic_setup()
 
 # To support OpenCV and any other conan-based libraries, conan_basic_setup() is almost all we need. However, the test targets require specific add_library invocations, which is provided by this additional macro provided by conanbuildinfo.cmake.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,54 +1,104 @@
-#  minimum required cmake version: 3.1.0
+#  Minimum required CMake version: 3.1.0
 cmake_minimum_required(VERSION 3.1.0)
 project(librealuvc LANGUAGES CXX C)
 
+# -------
+# Modules
+# -------
+
+# Include modules in "{project}/CMake/".
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" CACHE PATH "cmake modules" FORCE)
 
-# include librealsense general configuration
+# ---------------------
+# General Configuration
+# ---------------------
+
 include(CMake/global_config.cmake)
 
+# C++ flags.
 config_cxx_flags()
 
-# include os specific macros
-# macro definition located at "CMake/global_config.cmake"
+# Include OS-specific macros.
+# Macro definitions located at "CMake/global_config.cmake".
 include(CMake/include_os.cmake)
 
-# set os specific configuration flags
-# macro definition located at "CMake/<OS>_config.cmake"
+# Set OS-specific configuration flags.
+# Macro definitions located at "CMake/<OS>_config.cmake".
 os_set_flags()
 
-# set global configuration flags
-# macro definition located at "CMake/global_config.cmake"
+# Set global configuration flags.
+# Macro definitions located at "CMake/global_config.cmake".
 global_set_flags()
+
+# ---------
+# Libraries
+# ---------
 
 message(STATUS "add_library: ${LRS_TARGET} SHARED: ${BUILD_SHARED_LIBS}")
 add_library(${LRS_TARGET} "")
 
-# add_OpenCV()
-find_package(OpenCV REQUIRED)
-set(DEPENDENCIES librealuvc ${OpenCV_LIBS})
-include_directories(${OpenCV_INCLUDE_DIRS})
+# Conan
+# -----
+# Basic Conan setup.
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
 
-add_library(OpenCV SHARED IMPORTED)
+# OpenCV
+# ------
 
-# global project configuration
-# macro definition located at "CMake/global_config.cmake"
+# CURRENT STATUS: Seeing if conan_basic_setup pulls in OpenCV just fine...
+
+# Old non-Conan OpenCV inclusion.
+# ---
+# # add_OpenCV() (from global_config.cmake)
+# find_package(OpenCV REQUIRED)
+# set(DEPENDENCIES librealuvc ${OpenCV_LIBS})
+# include_directories(${OpenCV_INCLUDE_DIRS})
+# add_library(OpenCV SHARED IMPORTED)
+# ---
+# Conan OpenCV.
+conan_define_targets()
+# find_package(OpenCV REQUIRED) # Nope
+# set(OpenCV_LIBS ${CONAN_LIBS_OPENCV})
+# set(OpenCV_INCLUDE_DIRS ${CONAN_INCLUDE_DIRS_OPENCV})
+# set(DEPENDENCIES librealuvc ${OpenCV_LIBS})
+# include_directories(${OpenCV_INCLUDE_DIRS})
+# target_link_libraries(${LRS_TARGET} PUBLIC ${OpenCV_LIBS})
+# target_include_directories(${LRS_TARGET} PUBLIC ${OpenCV_INCLUDE_DIR})
+
+# ------------------
+# More Configuration
+# ------------------
+
+# Global project configuration.
+# Macro definitions located at "CMake/global_config.cmake".
 global_target_config()
 
-# configure the project according to OS specific requirments
-# macro definition located at "CMake/<OS>_config.cmake"
+# Configure the project according to OS-specific requirments.
+# Macro definitions located at "CMake/<OS>_config.cmake".
 os_target_config()
+
+# ----------
+# CMakeLists
+# ----------
 
 include(include/CMakeLists.txt)
 include(src/CMakeLists.txt)
 include(third-party/CMakeLists.txt)
 
-# set library version
+# -------------
+# Build Version
+# -------------
+
 set_target_properties(${LRS_TARGET} PROPERTIES
   WINDOWS_EXPORT_ALL_SYMBOLS ON
   VERSION ${REALUVC_VERSION_STRING}
   SOVERSION ${REALUVC_VERSION_MAJOR}
 )
+
+# -----------------------
+# Included Subdirectories
+# -----------------------
 
 add_subdirectory(wrappers)
 
@@ -59,5 +109,9 @@ endif()
 if(BUILD_UNIT_TESTS)
   add_subdirectory(unit-tests)
 endif()
+
+# --------------------------------
+# Installation Build Target Config
+# --------------------------------
 
 include(CMake/install_config.cmake)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,31 @@
+from conans import ConanFile, CMake
+
+class PocoTimerConan(ConanFile):
+  settings = "os", "compiler", "build_type", "arch"
+  # requires=[
+  #   "boost/1.70.0@conan/stable",
+  #   "eigen/3.3.7@conan/stable",
+  #   "opencv/4.1.0@conan/stable",
+  #   "protobuf/3.8.0@conan/stable"
+  # ]
+  requires=[
+    "boost/1.70.0",
+    "eigen/3.3.7",
+    "opencv/4.5.0",
+    "protobuf/3.9.1"
+  ]
+  generators = "cmake"
+  
+  # Configuration for dependencies.
+  # default_options = {"poco:shared": True, "openssl:shared": True}
+
+  # e.g. copy all dll files from the "bin" package folder to the "bin" project folder
+  # e.g. copy all dylib files from the "lib" package folder to the "bin" project folder 
+  #  def imports(self):
+  #     self.copy("*.dll", dst="bin", src="bin") # From bin to bin
+  #     self.copy("*.dylib*", dst="bin", src="lib") # From lib to bin
+  
+  def build(self):
+      cmake = CMake(self)
+      cmake.configure()
+      cmake.build()

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,6 +18,7 @@ class PocoTimerConan(ConanFile):
   
   # Configuration for dependencies.
   # default_options = {"poco:shared": True, "openssl:shared": True}
+  default_options = { "opencv:shared": True }
 
   # e.g. copy all dll files from the "bin" package folder to the "bin" project folder
   # e.g. copy all dylib files from the "lib" package folder to the "bin" project folder 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,25 @@
+# leapmotion/librealuvc
+
+A fork of librealuvc to support the Rigel through UVC.
+
+## Conan + CMake
+
+These instructions are still a work-in-progress.
+
+```sh
+conan install . --install-folder build -r conan-center
+conan build . --install-folder build -r conan-center
+```
+
+The `-r conan-center` part is necessary if you've modified your `conan remote` setup for building e.g. libtrack by changing your default remote to gitlab. If you don't have conan-center defined you may need to add it:
+```sh
+conan remote add conan-center https://conan.bintray.com
+```
+
+If `conan build` fails, you'll likely see CMake error output. You can re-attempt configuration/generation using your CMake interface of choice (e.g. cmake-gui) and debug from there.
+
+# Original readme.md below
+
 ## Overview
 This library provides a portable backend to UVC-compliant cameras and other
 USB devices (e.g. motion sensors), with support for UVC Extension Units.

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ These instructions are still a work-in-progress.
 
 ```sh
 conan install . --install-folder build -r conan-center
-conan build . --install-folder build -r conan-center
+conan build . --build-folder build
 ```
 
 The `-r conan-center` part is necessary if you've modified your `conan remote` setup for building e.g. libtrack by changing your default remote to gitlab. If you don't have conan-center defined you may need to add it:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ target_sources(${LRS_TARGET}
 
 target_link_libraries(${LRS_TARGET} PUBLIC ${OpenCV_LIBS})
 
-if(TARGET OpenCV::highgui)
+if(TARGET CONAN_PKG::opencv)
   add_executable(
       mytest
         "${CMAKE_CURRENT_LIST_DIR}/mytest.cpp"
@@ -48,7 +48,7 @@ if(TARGET OpenCV::highgui)
   target_link_libraries(
       mytest
           ${LRS_TARGET}
-          ${OpenCV_LIBS}
+          CONAN_PKG::opencv
   )
 
   add_executable(
@@ -60,8 +60,6 @@ if(TARGET OpenCV::highgui)
   target_link_libraries(
       viewer
           ${LRS_TARGET}
-          OpenCV::highgui
+          CONAN_PKG::opencv
   )
 endif()
-
-


### PR DESCRIPTION
~**Work-in-progress. Do not merge.**~  Works great! -John

Hi platforms team! This is Nick from the tracking team (they/them). I wanted to have librealuvc set up for easy building so I could get low-level access to the Rigel camera & images for some hacking/experimental projects.

This PR sets up a conanfile.py for conan to install these dependencies. You can contrast these version numbers against the numbers in `build.sh`; these were picked to be as close as possible while still pulling from the conan-center repository:
- "boost/1.70.0",
- "eigen/3.3.7",
- "opencv/4.5.0",
- "protobuf/3.9.1"

It also modifies the readme to start with conan-based dependency installation instructions. I don't know for sure if my local machine is already set up for other dependencies, but if that's the case, we should just be able to add more libraries to the conanfile to have a proper build configuration.
    
It also modifies the central CMakeLists.txt to:
  - Have some explicit structure, added while I was trying to understand what was going on
  - Add and document the necessary invocations that tie in to the conan setup
  
I currently think this branch is essentially "done" for having a basic conan build setup; running the commands in the readme now, I can quickly build and successfully run `viewer.exe` and get Rigel images out. From the readme:
```sh
conan install . --install-folder build -r conan-center
conan build . --build-folder build
```

The `-r conan-center` part is necessary if you've modified your `conan remote` setup for building e.g. libtrack by changing your default remote to gitlab. If you don't have conan-center defined you may need to add it:
```sh
conan remote add conan-center https://conan.bintray.com
```

However, librealuvc is important to the libtrack stack, so I expect we'll want to sync a bit before accepting a change like this, since it changes some of the pulled-in dependency versions in order to easily reference available versions in the conan-center package repository.

---

Hi, this is John from the Tracking Team.   I just added Github Actions Continuous Integration to this PR to help everyone verify that it works (on Windows).  This should make it easier to test and merge new PRs coming down the pipeline.